### PR TITLE
S4. Confirm Selections Template Functionality Works

### DIFF
--- a/src/questionnaire-category/questionnaire-category.service.ts
+++ b/src/questionnaire-category/questionnaire-category.service.ts
@@ -74,7 +74,6 @@ export class QuestionnaireCategoryService {
             linkToInitalSelection: body.isCategoryLinkedInitialSelections,
             linkToPaintSelection: body.isCategoryLinkedPaintSelections,
             questionnaireTemplateId: template.id,
-            phaseId: body.linkedPhase || null
           },
           omit: {
             isDeleted: true,
@@ -127,6 +126,7 @@ export class QuestionnaireCategoryService {
             questions: {
               where: {
                 isDeleted: false,
+                linkToQuestionnaire: true,
               },
               include: {
                 answers: true,
@@ -141,6 +141,9 @@ export class QuestionnaireCategoryService {
               }
             },
           },
+          orderBy: {
+            questionnaireOrder: 'asc'
+          }
         });
         return { categories };
       }
@@ -203,7 +206,6 @@ export class QuestionnaireCategoryService {
             linkToPhase: body.isCategoryLinkedPaintSelections,
             linkToInitalSelection: body.isCategoryLinkedInitialSelections,
             linkToPaintSelection: body.isCategoryLinkedPaintSelections,
-            phaseId: body.linkedPhase || null
           },
         });
         return { category, message: ResponseMessages.CATEGORY_UPDATED };
@@ -311,11 +313,15 @@ export class QuestionnaireCategoryService {
             questions: {
               where: {
                 isDeleted: false,
+                linkToQuestionnaire: true,
               },
               orderBy: {
                 questionOrder: 'asc'
               }
             }
+          },
+          orderBy: {
+            questionnaireOrder: 'asc'
           }
         });
 
@@ -424,6 +430,7 @@ export class QuestionnaireCategoryService {
                   where: {
                     isDeleted: false,
                     isCompanyCategory: true,
+                    linkToQuestionnaire: true,
                   },
                   omit: {
                     isDeleted: true,
@@ -434,6 +441,7 @@ export class QuestionnaireCategoryService {
                     questions: {
                       where: {
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                       },
                       orderBy: {
                         questionOrder: 'asc'
@@ -498,6 +506,7 @@ export class QuestionnaireCategoryService {
                   where: {
                     isDeleted: false,
                     isCompanyCategory: true,
+                    linkToQuestionnaire: true,
                   },
                   omit: {
                     isDeleted: true,
@@ -508,6 +517,7 @@ export class QuestionnaireCategoryService {
                     questions: {
                       where: {
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                       },
                       orderBy: {
                         questionOrder: 'asc'

--- a/src/questionnaire-category/validators/create-update-category.ts
+++ b/src/questionnaire-category/validators/create-update-category.ts
@@ -22,8 +22,4 @@ export class CreateUpdateCategoryDTO {
     @IsBoolean()
     @IsOptional()
     isCategoryLinkedPaintSelections: boolean
-
-    @IsNumber()
-    @IsOptional()
-    linkedPhase: number
 }

--- a/src/questionnaire-template/questionnaire-template.service.ts
+++ b/src/questionnaire-template/questionnaire-template.service.ts
@@ -42,6 +42,7 @@ export class QuestionnaireTemplateService {
                             where: {
                                 isDeleted: false,
                                 isCompanyCategory: false,
+                                linkToQuestionnaire: true,
                             },
                             omit: {
                                 isDeleted: true,
@@ -53,7 +54,8 @@ export class QuestionnaireTemplateService {
                                     omit: {
                                         isDeleted: true,
                                         categoryId: true,
-                                        questionnaireTemplateId: true
+                                        questionnaireTemplateId: true,
+                                        linkToQuestionnaire: true,
                                     },
                                     orderBy: {
                                         questionOrder: 'asc'

--- a/src/selection-template/selection-template.service.ts
+++ b/src/selection-template/selection-template.service.ts
@@ -119,9 +119,6 @@ export class SelectionTemplateService {
                     include: {
                         questions: {
                             where: quesWhereClause,
-                            include: {
-                                answers: true,
-                            },
                             omit: {
                                 isDeleted: true,
                                 categoryId: true,
@@ -415,9 +412,6 @@ export class SelectionTemplateService {
                     include: {
                         questions: {
                             where: quesWhereClause,
-                            include: {
-                                answers: true,
-                            },
                             omit: {
                                 isDeleted: true,
                                 categoryId: true,
@@ -835,9 +829,6 @@ export class SelectionTemplateService {
                             where: {
                                 isDeleted: false,
                             },
-                            include: {
-                                answers: {},
-                            },
                             orderBy: {
                                 questionOrder: 'asc'
                             }
@@ -906,9 +897,6 @@ export class SelectionTemplateService {
                         questions: {
                             where: {
                                 isDeleted: false,
-                            },
-                            include: {
-                                answers: {},
                             },
                             orderBy: {
                                 questionOrder: "asc"
@@ -987,7 +975,7 @@ export class SelectionTemplateService {
 
                 let questionWhereClause: any = {
                     questionnaireTemplateId: templateId,
-                    categoryId: body.categoryId,
+                    isDeleted: false,
                 }
                 if (templateType === TemplateType.SELECTION_INITIAL) {
                     categoryWhereClause.linkToInitalSelection = true;

--- a/src/template-question/template-question.service.ts
+++ b/src/template-question/template-question.service.ts
@@ -23,9 +23,7 @@ export class TemplateQuestionService {
                         isDeleted: false
                     }
                 });
-                if (!company) {
-                    throw new ForbiddenException("Action Not Allowed");
-                }
+                if (!company) throw new ForbiddenException("Action Not Allowed");
 
                 // Get the highest question order for the given templateId and categoryId
                 let maxOrder = await this.databaseService.templateQuestion.aggregate({
@@ -39,11 +37,35 @@ export class TemplateQuestionService {
                     }
                 })
 
+                // Find the category if it exists and is not deleted.
+                let categoryItem = await this.databaseService.category.findUniqueOrThrow({
+                    where: {
+                        id: categoryId,
+                        isDeleted: false,
+                    }
+                });
+                // set the update data.
+                const updateData = {
+                    ...(body.linkedSelections.includes(SelectionTemplates.INITIAL_SELECTION) && !categoryItem.linkToInitalSelection && { linkToInitalSelection: true }),
+                    ...(body.linkedSelections.includes(SelectionTemplates.PAINT_SELECTION) && !categoryItem.linkToPaintSelection && { linkToPaintSelection: true })
+                };
+
+                // Update the category if there are changes to be made.
+                if (Object.keys(updateData).length > 0) {
+                    categoryItem = await this.databaseService.category.update({
+                        where: {
+                            id: categoryId,
+                            isDeleted: false,
+                        },
+                        data: updateData
+                    });
+                }
+
                 // if body.questionOrder = 0 , set it to maxOrder + 1
                 let order = body.questionOrder === 0
                     ? (maxOrder._max.questionOrder ?? 0) + 1
                     : body.questionOrder
-
+                // create the question
                 let question = await this.databaseService.templateQuestion.create({
                     data: {
                         question: body.question,
@@ -55,7 +77,6 @@ export class TemplateQuestionService {
                         linkToPaintSelection: body.linkedSelections.includes(SelectionTemplates.PAINT_SELECTION),
                         questionnaireTemplateId: templateId,
                         categoryId: categoryId,
-                        phaseId: body.linkedPhase || null,
                         contractorIds: body.contractorIds
                     },
                     omit: {
@@ -70,11 +91,13 @@ export class TemplateQuestionService {
                         id: categoryId,
                         isCompanyCategory: true,
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                     },
                     include: {
                         questions: {
                             where: {
                                 isDeleted: false,
+                                linkToQuestionnaire: true,
                             },
                             orderBy: {
                                 questionOrder: 'asc'
@@ -119,6 +142,7 @@ export class TemplateQuestionService {
                     where: {
                         categoryId: categoryId,
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                     },
                     omit: {
                         isDeleted: true
@@ -161,6 +185,7 @@ export class TemplateQuestionService {
                         id: questionId,
                         categoryId: categoryId,
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                     },
                     omit: {
                         isDeleted: true
@@ -199,6 +224,39 @@ export class TemplateQuestionService {
                     throw new ForbiddenException("Action Not Allowed");
                 }
 
+                let categoryItem = await this.databaseService.category.findUniqueOrThrow({
+                    where: {
+                        id: categoryId,
+                        isDeleted: false,
+                    }
+                });
+
+                if (!categoryItem.linkToInitalSelection || !categoryItem.linkToPaintSelection) {
+                    const updateData = {
+                        ...(
+                            body.linkedSelections.includes(SelectionTemplates.INITIAL_SELECTION) &&
+                            !categoryItem.linkToInitalSelection &&
+                            { linkToInitalSelection: true }
+                        ),
+                        ...(
+                            body.linkedSelections.includes(SelectionTemplates.PAINT_SELECTION) &&
+                            !categoryItem.linkToPaintSelection &&
+                            { linkToPaintSelection: true }
+                        )
+                    }
+
+                    // Update the category if there are changes to be made.
+                    if (Object.keys(updateData).length > 0) {
+                        categoryItem = await this.databaseService.category.update({
+                            where: {
+                                id: categoryId,
+                                isDeleted: false,
+                            },
+                            data: updateData
+                        });
+                    }
+                }
+
                 let question = await this.databaseService.templateQuestion.update({
                     where: {
                         id: questionId,
@@ -212,7 +270,6 @@ export class TemplateQuestionService {
                         linkToPhase: body.isQuestionLinkedPhase,
                         linkToInitalSelection: body.linkedSelections.includes(SelectionTemplates.INITIAL_SELECTION),
                         linkToPaintSelection: body.linkedSelections.includes(SelectionTemplates.PAINT_SELECTION),
-                        phaseId: body.linkedPhase || null,
                         contractorIds: body.contractorIds
                     },
                     omit: {
@@ -225,11 +282,13 @@ export class TemplateQuestionService {
                         id: categoryId,
                         isCompanyCategory: true,
                         isDeleted: false,
+                        linkToQuestionnaire: true,
                     },
                     include: {
                         questions: {
                             where: {
                                 isDeleted: false,
+                                linkToQuestionnaire: true,
                             },
                             orderBy: {
                                 questionOrder: 'asc'
@@ -329,6 +388,7 @@ export class TemplateQuestionService {
                         questions: {
                             where: {
                                 isDeleted: false,
+                                linkToQuestionnaire: true,
                             },
                             orderBy: {
                                 questionOrder: 'asc'
@@ -439,11 +499,13 @@ export class TemplateQuestionService {
                                 questionnaireTemplateId: templateId,
                                 isCompanyCategory: true,
                                 isDeleted: false,
+                                linkToQuestionnaire: true,
                             },
                             include: {
                                 questions: {
                                     where: {
                                         isDeleted: false,
+                                        linkToQuestionnaire: true,
                                     },
                                     orderBy: {
                                         questionOrder: 'asc'
@@ -494,11 +556,13 @@ export class TemplateQuestionService {
                                 questionnaireTemplateId: templateId,
                                 isCompanyCategory: true,
                                 isDeleted: false,
+                                linkToQuestionnaire: true,
                             },
                             include: {
                                 questions: {
                                     where: {
                                         isDeleted: false,
+                                        linkToQuestionnaire: true
                                     },
                                     orderBy: {
                                         questionOrder: 'asc'

--- a/src/template-question/validators/create-update-question.ts
+++ b/src/template-question/validators/create-update-question.ts
@@ -21,10 +21,6 @@ export class CreateUpdateQuestionDTO {
     @IsOptional()
     isQuestionLinkedPhase: boolean = false
 
-    @IsNumber()
-    @IsOptional()
-    linkedPhase: number
-
     @IsBoolean()
     @IsOptional()
     isQuestionLinkedSelections: boolean = false


### PR DESCRIPTION
- Categories should have the ability to add questions even if they are linked from the questionnaire template.
- Remove the Phase Select option when the Link Category to Paint Selections checkbox is checked when creating or editing a category in the Questionnaire template.
- In the contractor select box when Link Question & Answer to Contractor Phase is checked, update the Contractor name option to Phase Name: Contractor Name.
- When a question is created/ updated and is linked to the initial or paint selection template, automatically link the category to the respective selection template if they are not.
- All items in the questionnaire and selection template should be expanded and visible on the initial page load.